### PR TITLE
Implement the capability to define if a store is writtable or not.

### DIFF
--- a/src/Config.Net.Integration.Storage.Net/BlobConfigStore.cs
+++ b/src/Config.Net.Integration.Storage.Net/BlobConfigStore.cs
@@ -10,8 +10,9 @@ namespace Config.Net.Integration.Storage.Net
    {
       private readonly IBlobStorage _blobs;
 
-      public BlobConfigStore(IBlobStorage blobs)
+      public BlobConfigStore(IBlobStorage blobs, bool canWrite = true)
       {
+         CanWrite = canWrite;
          _blobs = blobs ?? throw new ArgumentNullException(nameof(blobs));
       }
 
@@ -19,7 +20,7 @@ namespace Config.Net.Integration.Storage.Net
 
       public bool CanRead => true;
 
-      public bool CanWrite => true;
+      public bool CanWrite { get; set; }
 
       public void Dispose()
       {

--- a/src/Config.Net.Integration.Storage.Net/TableConfigStore.cs
+++ b/src/Config.Net.Integration.Storage.Net/TableConfigStore.cs
@@ -11,18 +11,19 @@ namespace Config.Net.Integration.Storage.Net
       private readonly string _tableName;
       private readonly string _partitionKey;
 
-      public TableConfigStore(ITableStorage tableStorage, string tableName, string partitionKey)
+      public TableConfigStore(ITableStorage tableStorage, string tableName, string partitionKey, bool canWrite = true)
       {
          _tableStorage = tableStorage;
          _tableName = tableName;
          _partitionKey = partitionKey;
+         CanWrite = canWrite;
       }
 
       public string Name => "Storage.Net Tables";
 
       public bool CanRead => true;
 
-      public bool CanWrite => true;
+      public bool CanWrite { get; set; }
 
       public void Dispose()
       {

--- a/src/Config.Net.Tests/TestStore.cs
+++ b/src/Config.Net.Tests/TestStore.cs
@@ -6,14 +6,15 @@ namespace Config.Net.Tests
    {
       public Dictionary<string, string> Map { get; private set; }
  
-      public TestStore()
+      public TestStore(bool canWrite = true)
       {
+         CanWrite = canWrite;
          Map = new Dictionary<string, string>();
       }
 
       public string Name { get { return "test";  } }
       public bool CanRead { get { return true; } }
-      public bool CanWrite { get { return true; } }
+      public bool CanWrite { get; set; }
 
       public string Read(string key)
       {

--- a/src/Config.Net/ConfigurationExtensions.cs
+++ b/src/Config.Net/ConfigurationExtensions.cs
@@ -35,9 +35,10 @@ namespace Config.Net
       /// <summary>
       /// Uses system environment variables
       /// </summary>
-      public static IConfigConfiguration UseEnvironmentVariables(this IConfigConfiguration configuration)
+      /// <param name="canWrite">Optional parameter to allow a read only usage of this store.</param>
+      public static IConfigConfiguration UseEnvironmentVariables(this IConfigConfiguration configuration, bool canWrite = true)
       {
-         configuration.AddStore(new EnvironmentVariablesStore());
+         configuration.AddStore(new EnvironmentVariablesStore(canWrite));
          return configuration;
       }
 
@@ -46,10 +47,11 @@ namespace Config.Net
       /// </summary>
       /// <param name="configuration"></param>
       /// <param name="iniFilePath">File does not have to exist, however it will be created as soon as you try to write to it.</param>
+      /// <param name="canWrite">Optional parameter to allow a read only usage of this store.</param>
       /// <returns></returns>
-      public static IConfigConfiguration UseIniFile(this IConfigConfiguration configuration, string iniFilePath)
+      public static IConfigConfiguration UseIniFile(this IConfigConfiguration configuration, string iniFilePath, bool canWrite = true)
       {
-         configuration.AddStore(new IniFileConfigStore(iniFilePath));
+         configuration.AddStore(new IniFileConfigStore(iniFilePath, canWrite));
          return configuration;
       }
 
@@ -58,9 +60,10 @@ namespace Config.Net
       /// </summary>
       /// <param name="configuration"></param>
       /// <returns></returns>
-      public static IConfigConfiguration UseInMemoryConfig(this IConfigConfiguration configuration)
+      /// <param name="canWrite">Optional parameter to allow a read only usage of this store.</param>
+      public static IConfigConfiguration UseInMemoryConfig(this IConfigConfiguration configuration, bool canWrite = true)
       {
-         configuration.AddStore(new InMemoryConfigStore());
+         configuration.AddStore(new InMemoryConfigStore(canWrite));
          return configuration;
       }
 
@@ -82,11 +85,12 @@ namespace Config.Net
       /// </summary>
       /// <param name="configuration">Configuration object.</param>
       /// <param name="jsonFilePath">Full path to json storage file.</param>
+      /// <param name="canWrite">Optional parameter to allow a read only usage of this store.</param>
       /// <returns>Changed configuration.</returns>
       /// <remarks>Storage file does not have to exist, however it will be created as soon as first write performed.</remarks>
-      public static IConfigConfiguration UseJsonFile(this IConfigConfiguration configuration, string jsonFilePath)
+      public static IConfigConfiguration UseJsonFile(this IConfigConfiguration configuration, string jsonFilePath, bool canWrite = true)
       {
-         configuration.AddStore(new JsonFileConfigStore(jsonFilePath));
+         configuration.AddStore(new JsonFileConfigStore(jsonFilePath, canWrite));
          return configuration;
       }
 

--- a/src/Config.Net/IConfigStore.cs
+++ b/src/Config.Net/IConfigStore.cs
@@ -20,7 +20,7 @@ namespace Config.Net
       /// <summary>
       /// Returns true if store supports write operation.
       /// </summary>
-      bool CanWrite { get; }
+      bool CanWrite { get; set; }
 
       /// <summary>
       /// Reads a key from the store.

--- a/src/Config.Net/Stores/AppConfigStore.cs
+++ b/src/Config.Net/Stores/AppConfigStore.cs
@@ -13,7 +13,12 @@ namespace Config.Net.Stores
 
       public bool CanRead => true;
 
-      public bool CanWrite => false;
+      public bool CanWrite { get; set; }
+
+      public AppConfigStore()
+	   {
+         CanWrite = false;
+	   }
 
       public string Read(string key)
       {

--- a/src/Config.Net/Stores/AssemblyConfigStore.cs
+++ b/src/Config.Net/Stores/AssemblyConfigStore.cs
@@ -19,6 +19,7 @@ namespace Config.Net.Stores
       /// <param name="assembly">reference to the assembly to look for</param>
       public AssemblyConfigStore(Assembly assembly)
       {
+         CanWrite = false;
          _configuration = ConfigurationManager.OpenExeConfiguration(assembly.Location);
       }
 
@@ -35,7 +36,7 @@ namespace Config.Net.Stores
       /// <summary>
       /// Store is not writeable
       /// </summary>
-      public bool CanWrite => false;
+      public bool CanWrite { get; set; }
 
       /// <summary>
       /// Reads the value by key

--- a/src/Config.Net/Stores/CommandLineConfigStore.cs
+++ b/src/Config.Net/Stores/CommandLineConfigStore.cs
@@ -13,7 +13,7 @@ namespace Config.Net.Stores
 
       public bool CanRead => true;
 
-      public bool CanWrite => false;
+      public bool CanWrite { get => false; set {  } }
 
       public string Name => "Command Line Arguments";
 

--- a/src/Config.Net/Stores/EnvironmentVariablesStore.cs
+++ b/src/Config.Net/Stores/EnvironmentVariablesStore.cs
@@ -8,6 +8,11 @@ namespace Config.Net.Stores
    /// </summary>
    class EnvironmentVariablesStore : IConfigStore
    {
+      public EnvironmentVariablesStore(bool canWrite = true)
+      {
+         CanWrite = canWrite;
+      }
+
       /// <summary>
       /// Readable
       /// </summary>
@@ -16,7 +21,7 @@ namespace Config.Net.Stores
       /// <summary>
       /// Writeable
       /// </summary>
-      public bool CanWrite => true;
+      public bool CanWrite { get; set; }
 
       /// <summary>
       /// Store name

--- a/src/Config.Net/Stores/InMemoryConfigStore.cs
+++ b/src/Config.Net/Stores/InMemoryConfigStore.cs
@@ -6,9 +6,14 @@ namespace Config.Net.Stores
    {
       public string Name => "InMemoryStore";
       public bool CanRead => true;
-      public bool CanWrite => true;
+      public bool CanWrite { get; set; }
 
       private readonly Dictionary<string, string> _data = new Dictionary<string, string>();
+
+      public InMemoryConfigStore(bool canWrite = true)
+      {
+         CanWrite = canWrite;
+      }
 
       public string Read(string key)
       {

--- a/src/Config.Net/Stores/IniFileConfigStore.cs
+++ b/src/Config.Net/Stores/IniFileConfigStore.cs
@@ -19,12 +19,14 @@ namespace Config.Net.Stores
       /// </summary>
       /// <param name="fullName">File does not have to exist, however it will be created as soon as you
       /// try to write to it</param>
-      public IniFileConfigStore(string fullName)
+      public IniFileConfigStore(string fullName, bool canWrite = true)
       {
          if (fullName == null) throw new ArgumentNullException(nameof(fullName));
 
          _fileName = Path.GetFileName(fullName);
          _fullName = fullName;
+
+         CanWrite = canWrite;
 
          string parentDirPath = Path.GetDirectoryName(fullName);
          if (string.IsNullOrEmpty(parentDirPath)) throw new IOException("the provided directory path is not valid");
@@ -40,7 +42,7 @@ namespace Config.Net.Stores
 
       public bool CanRead => true;
 
-      public bool CanWrite => true;
+      public bool CanWrite { get; set; }
 
       public string Read(string fullKey)
       {

--- a/src/Config.Net/Stores/JsonFileConfigStore.cs
+++ b/src/Config.Net/Stores/JsonFileConfigStore.cs
@@ -22,12 +22,14 @@ namespace Config.Net.Stores
         /// <exception cref="ArgumentNullException"><paramref name="fullName"/> is null.</exception>
         /// <exception cref="IOException">Provided path is not valid.</exception>
         /// <remarks>Storage file does not have to exist, however it will be created as soon as first write performed.</remarks>
-        public JsonFileConfigStore(string fullName)
+        public JsonFileConfigStore(string fullName, bool canWrite = true)
         {
             if (fullName == null) throw new ArgumentNullException(nameof(fullName));
 
             _fullName = fullName;
             _fileName = Path.GetFileName(fullName);
+
+            CanWrite = canWrite;
 
             var parentDirPath = Path.GetDirectoryName(fullName);
 
@@ -47,7 +49,7 @@ namespace Config.Net.Stores
 
         public bool CanRead => true;
 
-        public bool CanWrite => true;
+        public bool CanWrite { get; set; }
 
         public string Read(string key)
         {


### PR DESCRIPTION
Hi, i made some tiny changes to be able to support more scenarios.

Exemple:

-  I want to be able to read params from a user private json file (let say in appdata/roaming)
- If the settings are not existing i want to read them from a public location (like a file in the binary folder)
- However, in this scenario i want to save only on the user private file, never in the public file.
