### PR TITLE
Add App.config custom config section storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This library eliminates the problem of having configuration in different places,
 - [Dynamic Configuration](doc/DynamicConfiguration.md)
 - Configuration Sources
   - [App.config](doc/Stores_AppConfig.md)
+  - [App.config custom section](doc/Stores_AppConfigSection.md)
   - [Command Line](doc/Stores_CommandLine.md)
   - [Environment Variables](doc/Stores_EnvironmentVariables.md)
   - [.INI files](doc/Stores_IniFile.md)

--- a/README.v3.md
+++ b/README.v3.md
@@ -164,6 +164,7 @@ The list of available built-in and external stores is maintained on this page:
 | Name                 | Readable | Writeable | Package  | Purpose                  |
 |----------------------|----------|-----------|----------|--------------------------|
 |[AppConfig](doc/Stores_AppConfig.md)|v|x|internal|.NET app.config files|
+|[AppConfigSection](doc/Stores_AppConfig.md)|v|x|internal|.NET app.config files (custom sections)|
 |[EnvironmentVariables](doc/Stores_EnvironmentVariables.md) | v        | v         | internal | OS environment variables |
 |[CommandLine](doc/Stores_CommandLine.md)|v|x|internal|Parsing command line as configuration source| 
 |[IniFile](doc/Stores_IniFile.md)              | v        | v         | internal | INI files |

--- a/doc/Stores_AppConfigSection.md
+++ b/doc/Stores_AppConfigSection.md
@@ -1,0 +1,29 @@
+# AppConfig Store
+
+To configure the store:
+
+```csharp
+IMySettings settings = new ConfigurationBuilder<IMySettings>()
+   .UseAppConfigSection("myCustomConfigSectionName1")
+   .UseAppConfigSection("myCustomConfigSectionName2")
+   .Build();
+```
+
+Sample usage in App.config (Web.config):
+
+```xml
+<configuration>
+  <configSections>
+    <section name="myCustomConfigSectionName1" type="Config.Net.Stores.Formats.AppConfigSection.AppConfigConfigurationSection, Config.Net" />
+    <section name="myCustomConfigSectionName2" type="Config.Net.Stores.Formats.AppConfigSection.AppConfigConfigurationSection, Config.Net" />
+  </configSections>
+  <myCustomConfigSectionName1>
+    <add key="MyConfigKey1" value="MyConfigValue1" />
+  </myCustomConfigSectionName1>
+  <myCustomConfigSectionName2>
+    <add key="MyConfigKey2" value="MyConfigValue2" />
+  </myCustomConfigSectionName2>
+</configuration>
+```
+
+It doesn't have any parameters. It's read-only, and forwards read operation to the standard [ConfigurationManager](https://msdn.microsoft.com/en-us/library/system.configuration.configurationmanager%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396) class.

--- a/src/Config.Net.sln
+++ b/src/Config.Net.sln
@@ -23,6 +23,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "doc", "doc", "{CDB02CCC-51F
 		..\README.v1.md = ..\README.v1.md
 		..\README.v3..md = ..\README.v3..md
 		..\doc\Stores_AppConfig.md = ..\doc\Stores_AppConfig.md
+		..\doc\Stores_AppConfigSection.md = ..\doc\Stores_AppConfigSection.md
 		..\doc\Stores_CommandLine.md = ..\doc\Stores_CommandLine.md
 		..\doc\Stores_EnvironmentVariables.md = ..\doc\Stores_EnvironmentVariables.md
 		..\doc\Stores_IniFile.md = ..\doc\Stores_IniFile.md

--- a/src/Config.Net/Config.Net.csproj
+++ b/src/Config.Net/Config.Net.csproj
@@ -57,6 +57,9 @@ new feature: configuration interfaces support methods</PackageReleaseNotes>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Stores\Formats\AppConfigSection\" />
+  </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
     <DefineConstants>$(DefineConstants);NETSTANDARD14</DefineConstants>
   </PropertyGroup>

--- a/src/Config.Net/ConfigurationExtensions.cs
+++ b/src/Config.Net/ConfigurationExtensions.cs
@@ -25,7 +25,7 @@ namespace Config.Net
       /// <summary>
       /// Standard app.config (web.config) builder custom configuration section store. Read-only.
       /// </summary>
-      public static ConfigurationBuilder<TInterface> UseAppConfig<TInterface>(this ConfigurationBuilder<TInterface> builder, string sectionName) where TInterface : class
+      public static ConfigurationBuilder<TInterface> UseAppConfigSection<TInterface>(this ConfigurationBuilder<TInterface> builder, string sectionName) where TInterface : class
       {
          builder.UseConfigStore(new AppConfigSectionStore(sectionName));
          return builder;

--- a/src/Config.Net/ConfigurationExtensions.cs
+++ b/src/Config.Net/ConfigurationExtensions.cs
@@ -23,6 +23,15 @@ namespace Config.Net
       }
 
       /// <summary>
+      /// Standard app.config (web.config) builder custom configuration section store. Read-only.
+      /// </summary>
+      public static ConfigurationBuilder<TInterface> UseAppConfig<TInterface>(this ConfigurationBuilder<TInterface> builder, string sectionName) where TInterface : class
+      {
+         builder.UseConfigStore(new AppConfigSectionStore(sectionName));
+         return builder;
+      }
+
+      /// <summary>
       /// Reads builder from the .dll.config or .exe.config file.
       /// </summary>
       /// <param name="builder"></param>

--- a/src/Config.Net/Stores/AppConfigSectionStore.cs
+++ b/src/Config.Net/Stores/AppConfigSectionStore.cs
@@ -13,12 +13,12 @@ namespace Config.Net.Stores
    {
       private readonly string _sectionName;
 
-      public UseAppConfigSectionStore(string sectionName)
+      public AppConfigSectionStore(string sectionName)
       {
          _sectionName = sectionName;
       }
 
-      public string Name => "App.config";
+      public string Name => $"App.config - section {_sectionName}";
 
       public bool CanRead => true;
 
@@ -36,7 +36,7 @@ namespace Config.Net.Stores
             return null;
          }
 
-         var element = configSection.Settings.Cast<AppConfigSectionElement>().SingleOrDefault(x => x.Key == key);
+         AppConfigSectionElement element = configSection.Settings.Cast<AppConfigSectionElement>().SingleOrDefault(x => x.Key == key);
          return element?.Value;
       }
 

--- a/src/Config.Net/Stores/AppConfigSectionStore.cs
+++ b/src/Config.Net/Stores/AppConfigSectionStore.cs
@@ -1,0 +1,53 @@
+﻿#if NETFULL
+using System;
+using System.Linq;
+using System.Configuration;
+using Config.Net.Stores.Formats.AppConfigSection;
+
+namespace Config.Net.Stores
+{
+   /// <summary>
+   /// Standard app.config (web.config) custom configuration section store. Read-only.
+   /// </summary>
+   class AppConfigSectionStore : IConfigStore
+   {
+      private readonly string _sectionName;
+
+      public UseAppConfigSectionStore(string sectionName)
+      {
+         _sectionName = sectionName;
+      }
+
+      public string Name => "App.config";
+
+      public bool CanRead => true;
+
+      public bool CanWrite => false;
+
+      public string Read(string key)
+      {
+         if (key == null)
+         {
+            return null;
+         }
+
+         if (!(ConfigurationManager.GetSection(_sectionName) is AppConfigConfigurationSection configSection))
+         {
+            return null;
+         }
+
+         var element = configSection.Settings.Cast<AppConfigSectionElement>().SingleOrDefault(x => x.Key == key);
+         return element?.Value;
+      }
+
+      public void Write(string key, string value)
+      {
+         throw new NotSupportedException();
+      }
+
+      public void Dispose()
+      {
+      }
+   }
+}
+#endif

--- a/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigConfigurationSection.cs
+++ b/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigConfigurationSection.cs
@@ -1,0 +1,16 @@
+﻿#if NETFULL
+using System.Configuration;
+
+namespace Config.Net.Stores.Formats.AppConfigSection
+{
+    public class AppConfigConfigurationSection : ConfigurationSection
+    {
+        [ConfigurationProperty("", IsRequired = true, IsDefaultCollection = true)]
+        public AppConfigSectionElementsCollection Settings
+        {
+            get => (AppConfigSectionElementsCollection)this[""];
+            set => this[""] = value;
+        }
+    }
+}
+#endif

--- a/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigConfigurationSection.cs
+++ b/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigConfigurationSection.cs
@@ -3,14 +3,14 @@ using System.Configuration;
 
 namespace Config.Net.Stores.Formats.AppConfigSection
 {
-    public class AppConfigConfigurationSection : ConfigurationSection
-    {
-        [ConfigurationProperty("", IsRequired = true, IsDefaultCollection = true)]
-        public AppConfigSectionElementsCollection Settings
-        {
-            get => (AppConfigSectionElementsCollection)this[""];
-            set => this[""] = value;
-        }
-    }
+   class AppConfigConfigurationSection : ConfigurationSection
+   {
+      [ConfigurationProperty("", IsRequired = true, IsDefaultCollection = true)]
+      public AppConfigSectionElementsCollection Settings
+      {
+         get => (AppConfigSectionElementsCollection)this[""];
+         set => this[""] = value;
+      }
+   }
 }
 #endif

--- a/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigSectionElement.cs
+++ b/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigSectionElement.cs
@@ -1,0 +1,26 @@
+﻿#if NETFULL
+using System.Configuration;
+
+namespace Config.Net.Stores.Formats.AppConfigSection
+{
+   public class AppConfigSectionElement : ConfigurationElement
+   {
+      private const string KeyAttributeName = "key";
+      private const string ValueAttributeName = "key";
+
+      [ConfigurationProperty(KeyAttributeName, IsKey = true, IsRequired = true)]
+      public string Key
+      {
+         get => (string)base[KeyAttributeName];
+         set => base[KeyAttributeName] = value;
+      }
+
+      [ConfigurationProperty(ValueAttributeName, IsRequired = true)]
+      public string Value
+      {
+         get => (string)base[ValueAttributeName];
+         set => base[ValueAttributeName] = value;
+      }
+   }
+}
+#endif

--- a/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigSectionElement.cs
+++ b/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigSectionElement.cs
@@ -3,7 +3,7 @@ using System.Configuration;
 
 namespace Config.Net.Stores.Formats.AppConfigSection
 {
-   public class AppConfigSectionElement : ConfigurationElement
+   class AppConfigSectionElement : ConfigurationElement
    {
       private const string KeyAttributeName = "key";
       private const string ValueAttributeName = "value";

--- a/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigSectionElement.cs
+++ b/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigSectionElement.cs
@@ -6,7 +6,7 @@ namespace Config.Net.Stores.Formats.AppConfigSection
    public class AppConfigSectionElement : ConfigurationElement
    {
       private const string KeyAttributeName = "key";
-      private const string ValueAttributeName = "key";
+      private const string ValueAttributeName = "value";
 
       [ConfigurationProperty(KeyAttributeName, IsKey = true, IsRequired = true)]
       public string Key

--- a/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigSectionElementsCollection.cs
+++ b/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigSectionElementsCollection.cs
@@ -1,0 +1,19 @@
+﻿#if NETFULL
+using System.Configuration;
+
+namespace Config.Net.Stores.Formats.AppConfigSection
+{
+    public class AppConfigSectionElementsCollection : ConfigurationElementCollection
+    {
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new AppConfigSectionElement();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return ((AppConfigSectionElement)element).Key;
+        }
+    }
+}
+#endif

--- a/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigSectionElementsCollection.cs
+++ b/src/Config.Net/Stores/Formats/AppConfigSection/AppConfigSectionElementsCollection.cs
@@ -3,17 +3,17 @@ using System.Configuration;
 
 namespace Config.Net.Stores.Formats.AppConfigSection
 {
-    public class AppConfigSectionElementsCollection : ConfigurationElementCollection
-    {
-        protected override ConfigurationElement CreateNewElement()
-        {
-            return new AppConfigSectionElement();
-        }
+   class AppConfigSectionElementsCollection : ConfigurationElementCollection
+   {
+      protected override ConfigurationElement CreateNewElement()
+      {
+         return new AppConfigSectionElement();
+      }
 
-        protected override object GetElementKey(ConfigurationElement element)
-        {
-            return ((AppConfigSectionElement)element).Key;
-        }
-    }
+      protected override object GetElementKey(ConfigurationElement element)
+      {
+         return ((AppConfigSectionElement)element).Key;
+      }
+   }
 }
 #endif


### PR DESCRIPTION
Not sure if it should be added as optional parameter to existing `UseAppConfig` extension method. Decided to create separate `UseAppConfigSection(string sectionName)` to make it more explicit. Documentation with sample usage is also provided. 

Let me know if you want tests for this functionality. Also I will understand if you recognize this PR useless - we use this store in several of our applications so decided to share it :)