### PR TITLE
Fixing typo.

### DIFF
--- a/doc/Stores_IniFile.md
+++ b/doc/Stores_IniFile.md
@@ -50,7 +50,7 @@ MyOption=my fancy value
 should use the definition
 
 ```csharp
-[Option(Name = "SectionOne.MyOption")]
+[Option(Alias = "SectionOne.MyOption")]
 string MyOption { get; }
 ```
 


### PR DESCRIPTION
`Option(Name = ....`  is changed to  `Option(Alias = ....`