### PR TITLE
Remove bool aliases

### DIFF
--- a/src/Config.Net.Tests/CoreParsersTest.cs
+++ b/src/Config.Net.Tests/CoreParsersTest.cs
@@ -15,10 +15,6 @@ namespace Config.Net.Tests
       [Theory]
       [InlineData("true", "true")]
       [InlineData("false", "false")]
-      [InlineData("yes", "true")]
-      [InlineData("no", "false")]
-      [InlineData("1", "true")]
-      [InlineData("0", "false")]
       public void Boolean__(string input, string expected)
       {
          object result;

--- a/src/Config.Net.Tests/LogicTest.cs
+++ b/src/Config.Net.Tests/LogicTest.cs
@@ -136,33 +136,6 @@ namespace Config.Net.Tests
       }
 
       [Fact]
-      public void ReadBooleanYesNoTest()
-      {
-         _store.Map["log-xml"] = "yes";
-         Assert.True(_settings.LogXml);
-
-         _store.Map["log-xml"] = "no";
-         Assert.False(_settings.LogXml);         
-      }
-
-      [Fact]
-      public void Read_PropertySyntax_Reads()
-      {
-         _store.Map["log-xml"] = "no";
-         Assert.False(_settings.LogXml);
-      }
-
-      [Fact]
-      public void ReadBoolean10Test()
-      {
-         _store.Map["log-xml"] = "1";
-         Assert.True(_settings.LogXml);
-
-         _store.Map["log-xml"] = "0";
-         Assert.False(_settings.LogXml);
-      }
-
-      [Fact]
       public void TimeSpanParserTest()
       {
          _store.Map["ping-interval"] = "01:02:03";

--- a/src/Config.Net/TypeParsers/CoreParsers.cs
+++ b/src/Config.Net/TypeParsers/CoreParsers.cs
@@ -11,13 +11,6 @@ namespace Config.Net.TypeParsers
    {
       public IEnumerable<Type> SupportedTypes => new[] { typeof(Uri), typeof(bool), typeof(Guid), typeof(DateTime) };
 
-      private static readonly Dictionary<string, bool> BooleanTrueValues =
-         new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
-      {
-         {"true", true},
-         {"yes", true},
-         {"1", true},
-      };
 
 
       public string ToRawString(object value)
@@ -58,13 +51,7 @@ namespace Config.Net.TypeParsers
 
          if(t == typeof(bool))
          {
-            if(BooleanTrueValues.ContainsKey(value))
-            {
-               result = true;
-               return true;
-            }
-
-            result = false;
+            result = bool.Parse(value);
             return true;
          }
 


### PR DESCRIPTION
This PR removes the bool alias conversions from the `CoreParsers` along with associated tests, based on issue #73. The bool conversion is replaced with the built-in `bool.Parse()`.