### PR TITLE
fixed incorrect collection reading for json and yaml

### DIFF
--- a/src/Config.Net.Json/Stores/JsonFileConfigStore.cs
+++ b/src/Config.Net.Json/Stores/JsonFileConfigStore.cs
@@ -69,7 +69,7 @@ namespace Config.Net.Json.Stores
                return arrayToken.Count.ToString();
             }
 
-            return "0";
+            return null;
          }
 
          return GetStringValue(valueToken);

--- a/src/Config.Net.Tests/MultipleConfigurationFilesTest.cs
+++ b/src/Config.Net.Tests/MultipleConfigurationFilesTest.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using Config.Net.Json.Stores;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Config.Net.Json.Stores;
+using Config.Net.Stores;
+using Xunit;
+
+namespace Config.Net.Tests
+{
+   public class MultipleConfigurationFilesTest : AbstractTestFixture
+   {
+      private IRootElement ConfigInterface { get; }
+
+      private const string configBasic = @"{
+'KeyA': 'basic',
+'KeyB': 'basic',
+    'Creds': [
+      {
+         'Username': 'user',
+         'Password': 'debug'
+   }
+]
+}";
+
+      private const string configOverride = @"{
+'KeyB': 'override',
+}";
+
+      public interface IRootElement
+      {
+         string KeyA { get; }
+         string KeyB { get; }
+         IEnumerable<IArrayElement> Creds { get; }
+      }
+
+      public interface IArrayElement
+      {
+         string Username { get; }
+
+         string Password { get; }
+      }
+
+      public MultipleConfigurationFilesTest()
+      {
+         var configurationBuilder = new ConfigurationBuilder<IRootElement>();
+         configurationBuilder
+            .UseJsonString(configOverride)
+            .UseJsonString(configBasic);
+         ConfigInterface = configurationBuilder.Build();
+      }
+
+      [Fact]
+      public void Read_Correct_Key()
+      {
+         Assert.Equal("basic", ConfigInterface.KeyA);
+         Assert.Equal("override", ConfigInterface.KeyB);
+      }
+
+      [Fact]
+      public void Read_Creds_IsNotEmpty()
+      {
+         Assert.NotEmpty(ConfigInterface.Creds);
+      }
+
+      [Fact]
+      public void Read_Correct_Creds()
+      {
+         Assert.Equal("user", ConfigInterface.Creds.ToArray().FirstOrDefault()?.Username);
+         Assert.Equal("debug", ConfigInterface.Creds.FirstOrDefault()?.Password);
+      }
+   }
+}

--- a/src/Config.Net.Yaml/Stores/YamlFileConfigStore.cs
+++ b/src/Config.Net.Yaml/Stores/YamlFileConfigStore.cs
@@ -126,7 +126,7 @@ namespace Config.Net.Yaml.Stores
                return sequenceNode.Count().ToString();
             }
 
-            return "0";
+            return null;
          }
 
          if (node is YamlScalarNode scalar)

--- a/src/Config.Net/Stores/IniFileConfigStore.cs
+++ b/src/Config.Net/Stores/IniFileConfigStore.cs
@@ -16,7 +16,7 @@ namespace Config.Net.Stores
 
       /// <summary>
       /// 
-      /// </summary>
+      /// </summary>r
       /// <param name="name">File does not have to exist, however it will be created as soon as you
       /// try to write to it</param>
       public IniFileConfigStore(string name, bool isFilePath, bool parseInlineComments)


### PR DESCRIPTION
fixes #105 

If you read a collection value from a json or yaml file and it is not declared, the library returns an empty collection. 
If you have configured that value in a second store, that store will never be accessed because the first one returns "0".
See the new test 'src/Config.Net.Json/Stores/JsonFileConfigStore.cs'