### PR TITLE
Change JsonFileConfigStore

### DIFF
--- a/src/Config.Net.Json/Stores/JsonFileConfigStore.cs
+++ b/src/Config.Net.Json/Stores/JsonFileConfigStore.cs
@@ -161,7 +161,7 @@ namespace Config.Net.Json.Stores
 
          // create backup of the destination file with old data
          string backupPath = _pathName + ".backup";
-         File.Copy(_pathName, backupPath);
+         File.Copy(_pathName, backupPath, true);
 
          // try to overwrite old file (_pathName) with new file (tempPath)
          // and delete backup with temporary file

--- a/src/Config.Net.Json/Stores/JsonFileConfigStore.cs
+++ b/src/Config.Net.Json/Stores/JsonFileConfigStore.cs
@@ -152,22 +152,34 @@ namespace Config.Net.Json.Stores
       {
          if (_jo == null) return;
 
-         // create temporary file with new data
+         // Create temporary file with new data.
          string json = _jo.ToString(Formatting.Indented);
          string tempPath = Path.GetTempPath() + Guid.NewGuid().ToString() + ".tmp";
          byte[] data = Encoding.UTF8.GetBytes(json);
          using (FileStream tempFile = File.Create(tempPath, 4096, FileOptions.WriteThrough))
             tempFile.Write(data, 0, data.Length);
 
-         // create backup of the destination file with old data
+         // Create backup of the destination file with old data.
+         // Since backup file is required, an exception allowed.
          string backupPath = _pathName + ".backup";
          File.Copy(_pathName, backupPath, true);
 
-         // try to overwrite old file (_pathName) with new file (tempPath)
-         // and delete backup with temporary file
-         File.Copy(tempPath, _pathName, true);
-         File.Delete(backupPath);
-         File.Delete(tempPath);
+         // Try to overwrite destination file (_pathName) with new one (tempPath)
+         // and delete backup with temporary file if successful.
+         // Otherwise, restore backup data and remove unneccessary files.
+         try
+         {
+            File.Copy(tempPath, _pathName, true);
+         }
+         catch (Exception)
+         {
+            File.Copy(backupPath, _pathName, true);
+         }
+         finally
+         {
+            File.Delete(backupPath);
+            File.Delete(tempPath);
+         }
       }
    }
 }


### PR DESCRIPTION
Trying to resolve issue #128, so here's my thoughts and changes.

- **JsonFileConfigStore** didn't check whether the filepath exists (it checked only in **WriteJsonFile()** method), so it could lead to store initialization with not really existing configuration source (I assumed that it can be created when there is an existing configuration file), but now it will, and if it doesn't - exception will be thrown.
- **File.Replace()** method [can throw an exception](https://docs.microsoft.com/en-us/dotnet/api/system.io.file.replace?view=net-6.0#system-io-file-replace(system-string-system-string-system-string)), because the project folder could exist on different volume from the system one where the temporary files get created within the Temp folder, so it cannot replace files. Instead, it is possible to use **File.Copy()** + **File.Delete()** methods as they do not throw such volumes depended exceptions.
- There was some sophisticated logic in copying and overwriting data files (which I actually could misunderstand), so it was simplified to this scenario:
1. Create temporary data file with new values to overwrite in Temp folder
2. Create backup file of old data file (if it's not possible, exception will be thrown, since backup file is important I guess)
3. Try to overwrite old data file with the new one
4. If something gone wrong, restore data with backup
5. Remove temporary and backup files
- The **Path.GetTempFileName()** method is not safe, since it uses some old API's and generates only four hex characters ID. Instead, now temporary _*.tmp_ file full path is generated with **Path.GetTempPath()** and **Guid.NewGuid()** parts.

I tried to fix only my issue, but there could be probably more changes to this class, e.g. now **ReadJsonFile()** method doesn't have to check if file exists since it was already done in the constructor. Anyway, hope some of these changes are useful.