### PR TITLE
Disabled AzureDevOpsVariableSetConfigStoreTest in a way where it stil…

### DIFF
--- a/src/Config.Net.Tests/Virtual/VirtualStoreTest.cs
+++ b/src/Config.Net.Tests/Virtual/VirtualStoreTest.cs
@@ -8,6 +8,7 @@ using Config.Net.Json.Stores;
 using Config.Net.Stores;
 using Config.Net.Stores.Impl.CommandLine;
 using Config.Net.Yaml.Stores;
+using Xunit;
 
 namespace Config.Net.Tests.Virtual
 {
@@ -168,16 +169,22 @@ namespace Config.Net.Tests.Virtual
             creds.AzureKeyVaultSecret);
       }
    }*/
-
-#if DEBUG
-   public class AzureDevOpsVariableSetConfigStoreTest : VirtualStoreTest
+   
+   [System.Diagnostics.CodeAnalysis.SuppressMessage(
+      "Usage",
+      "xUnit1000:Test classes must be public",
+      
+      Justification = "Disabled because this is not implemented yet, change internal to public " +
+                      "once implemented to test")]
+   
+   //public class AzureDevOpsVariableSetConfigStoreTest : VirtualStoreTest
+   internal class AzureDevOpsVariableSetConfigStoreTest : VirtualStoreTest
    {
       protected override IConfigStore CreateStore()
       {
          return new AzureDevOpsVariableSetConfigStore(creds.AzDevOpsOrg, creds.AzDevOpsProject, creds.AzDevOpsPat, creds.AzDeOpsVarId);
       }
    }
-#endif
 
-#endregion
+   #endregion
 }


### PR DESCRIPTION
Disabled AzureDevOpsVariableSetConfigStoreTest in a way where it still shows up in tests runner, just as Inconclusive.

Left instructions on how to re-enable once it's implemented.

As far as I can tell, xunit does not have a way to skip the entire class, and skipping just the overridden method does not prevent exceptions from being thrown when all tests are run on the object that is now not set up properly.

If there's a better way to do this, I'm all ears. 

It may also be an option to just change how the tests are set up so that [Fact(Skip = "reason")] works and doesn't let the ensuing tests run on the AzureDevOpsVariableSetConfigStoreTest class. 

There may also just be a dumb reason why #if DEBUG isn't working in Rider for me.

I promise I did some research on xunit and figuring out how to ignore things, but unfortunately, I don't know what I don't know, which is quite a lot. Hence why I'm trying to get into collaboration and learn.

Please let me know if there's something I can do better. Right now I figure small, granular pull requests are better since you can pick and choose what to keep/drop.