### PR TITLE
Escaping and unescaping new line characters

### DIFF
--- a/src/Config.Net.Tests/Stores/Formats/IniKeyValueTest.cs
+++ b/src/Config.Net.Tests/Stores/Formats/IniKeyValueTest.cs
@@ -6,17 +6,27 @@ namespace Config.Net.Tests.Stores.Formats
    public class IniKeyValueTest
    {
       [Theory]
-      [InlineData("key=value", "key", "value")]
-      [InlineData("key=value;123", "key", "value")]
-      [InlineData("key==value", "key", "=value")]
-      [InlineData("key=value;value;value", "key", "value;value")]
-      [InlineData("key=value=value;value", "key", "value=value")]
-      public void FromLine_ParsingInlineComments(string input, string expectedKey, string expectedValue)
+      [InlineData("key=value", "key", "value", null)]
+      [InlineData("key=value;123", "key", "value", "123")]
+      [InlineData("key==value", "key", "=value", null)]
+      [InlineData("key=value;value;value", "key", "value;value", "value")]
+      [InlineData("key=value=value;value", "key", "value=value", "value")]
+      [InlineData("key=value;rest;", "key", "value;rest", "")]
+      public void FromLine_ParsingInlineComments(string input, string expectedKey, string expectedValue, string expectedComment)
       {
          IniKeyValue kv = IniKeyValue.FromLine(input, true);
 
          Assert.Equal(expectedKey, kv.Key);
          Assert.Equal(expectedValue, kv.Value);
+         
+         if (expectedComment == null)
+         {
+            Assert.Null(kv.Comment);
+         }
+         else
+         {
+            Assert.Equal(expectedComment, kv.Comment.Value);
+         }
       }
 
       [Theory]
@@ -31,7 +41,7 @@ namespace Config.Net.Tests.Stores.Formats
 
          Assert.Equal(expectedKey, kv.Key);
          Assert.Equal(expectedValue, kv.Value);
+         Assert.Null(kv.Comment);
       }
-
    }
 }

--- a/src/Config.Net.Tests/Stores/Formats/IniKeyValueTest.cs
+++ b/src/Config.Net.Tests/Stores/Formats/IniKeyValueTest.cs
@@ -14,19 +14,7 @@ namespace Config.Net.Tests.Stores.Formats
       [InlineData("key=value;rest;", "key", "value;rest", "")]
       public void FromLine_ParsingInlineComments(string input, string expectedKey, string expectedValue, string expectedComment)
       {
-         IniKeyValue kv = IniKeyValue.FromLine(input, true);
-
-         Assert.Equal(expectedKey, kv.Key);
-         Assert.Equal(expectedValue, kv.Value);
-         
-         if (expectedComment == null)
-         {
-            Assert.Null(kv.Comment);
-         }
-         else
-         {
-            Assert.Equal(expectedComment, kv.Comment.Value);
-         }
+         FromLine_DoTest(true, false, input, expectedKey, expectedValue, expectedComment);
       }
 
       [Theory]
@@ -37,11 +25,32 @@ namespace Config.Net.Tests.Stores.Formats
       [InlineData("key=value=value;value", "key", "value=value;value")]
       public void FromLine_IgnoringInlineComments(string input, string expectedKey, string expectedValue)
       {
-         IniKeyValue kv = IniKeyValue.FromLine(input, false);
+         FromLine_DoTest(false, false, input, expectedKey, expectedValue, null);
+      }
+
+      [Theory]
+      [InlineData(true, @"k1\r\nk2=v1\r\nv2;c1\r\nc2", "k1\r\nk2", "v1\r\nv2", "c1\r\nc2")]
+      [InlineData(false, @"k1\r\nk2=v1\r\nv2;c1\r\nc2", @"k1\r\nk2", @"v1\r\nv2", @"c1\r\nc2")]
+      public void FromLine_UnescapeNewLines(bool unescapeNewLines, string input, string expectedKey, string expectedValue, string expectedComment)
+      {
+         FromLine_DoTest(true, unescapeNewLines, input, expectedKey, expectedValue, expectedComment);
+      }
+
+      private static void FromLine_DoTest(bool parseInlineComments, bool unescapeNewLines, string input, string expectedKey, string expectedValue, string expectedComment)
+      {
+         IniKeyValue kv = IniKeyValue.FromLine(input, parseInlineComments, unescapeNewLines);
 
          Assert.Equal(expectedKey, kv.Key);
          Assert.Equal(expectedValue, kv.Value);
-         Assert.Null(kv.Comment);
+
+         if (expectedComment == null)
+         {
+            Assert.Null(kv.Comment);
+         }
+         else
+         {
+            Assert.Equal(expectedComment, kv.Comment.Value);
+         }
       }
    }
 }

--- a/src/Config.Net.Tests/Stores/Formats/StructuredIniFileTest.cs
+++ b/src/Config.Net.Tests/Stores/Formats/StructuredIniFileTest.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Config.Net.Stores.Formats.Ini;
+using Xunit;
+
+namespace Config.Net.Tests.Stores.Formats
+{
+   public class StructuredIniFileTest : AbstractTestFixture
+   {
+      [Fact]
+      public void WriteInlineCommentWithNewLine()
+      {
+         string fullPath = Path.Combine(TestDir.FullName, Guid.NewGuid() + ".ini");
+         string content = @"key=value ;c1\r\nc2
+";
+
+         StructuredIniFile file;
+         using (Stream input = new MemoryStream(Encoding.UTF8.GetBytes(content)))
+         {
+            file = StructuredIniFile.ReadFrom(input, true, true);
+         }
+
+         using (Stream output = File.OpenWrite(fullPath))
+         {
+            file.WriteTo(output);
+         }
+
+         string resultText = File.ReadAllText(fullPath);
+         Assert.Equal(content, resultText);
+      }
+   }
+}

--- a/src/Config.Net.Tests/Stores/IniFileConfigStoreTest.cs
+++ b/src/Config.Net.Tests/Stores/IniFileConfigStoreTest.cs
@@ -85,5 +85,23 @@ key0=s1value0
 key0=s2value0
 ", resultText, false, true);
       }
+
+      [Theory]
+      [InlineData("key", "l1\r\nl2", @"key=l1\r\nl2")]
+      [InlineData("key", "l1\rl2", @"key=l1\rl2")]
+      [InlineData("key", "l1\nl2", @"key=l1\nl2")]
+      [InlineData("k1\r\nk2", "value", @"k1\r\nk2=value")]
+      [InlineData("k1\rk2", "value", @"k1\rk2=value")]
+      [InlineData("k1\nk2", "value", @"k1\nk2=value")]
+      public void Write_NewLine(string key, string value, string expectedOutput)
+      {
+         string fullPath = Path.Combine(TestDir.FullName, Guid.NewGuid() + ".ini");
+         var ini = new IniFileConfigStore(fullPath, true, true);
+
+         ini.Write(key, value);
+
+         string resultText = File.ReadAllText(fullPath);
+         Assert.Equal(expectedOutput + "\r\n", resultText);
+      }
    }
 }

--- a/src/Config.Net/Stores/Formats/Ini/IniComment.cs
+++ b/src/Config.Net/Stores/Formats/Ini/IniComment.cs
@@ -11,6 +11,11 @@
 
       public string Value { get; set; }
 
+      public string EscapedValue
+      {
+         get { return Value.Replace("\r", @"\r").Replace("\n", @"\n"); }
+      }
+
       public override string ToString() => Value;
    }
 }

--- a/src/Config.Net/Stores/Formats/Ini/IniKeyValue.cs
+++ b/src/Config.Net/Stores/Formats/Ini/IniKeyValue.cs
@@ -18,6 +18,16 @@ namespace Config.Net.Stores.Formats.Ini
 
       public string Value { get; set; }
 
+      public string EscapedKey
+      {
+         get { return Key.Replace("\r", @"\r").Replace("\n", @"\n"); }
+      }
+
+      public string EscapedValue
+      {
+         get { return Value.Replace("\r", @"\r").Replace("\n", @"\n"); }
+      }
+
       public IniComment? Comment { get; }
 
       public static IniKeyValue? FromLine(string line, bool parseInlineComments)

--- a/src/Config.Net/Stores/Formats/Ini/IniKeyValue.cs
+++ b/src/Config.Net/Stores/Formats/Ini/IniKeyValue.cs
@@ -30,7 +30,7 @@ namespace Config.Net.Stores.Formats.Ini
 
       public IniComment? Comment { get; }
 
-      public static IniKeyValue? FromLine(string line, bool parseInlineComments)
+      public static IniKeyValue? FromLine(string line, bool parseInlineComments, bool unescapeNewLines = false)
       {
          int idx = line.IndexOf(KeyValueSeparator, StringComparison.CurrentCulture);
          if(idx == -1) return null;
@@ -49,7 +49,19 @@ namespace Config.Net.Stores.Formats.Ini
             }
          }
 
+         if(unescapeNewLines)
+         {
+            key = UnescapeString(key);
+            value = UnescapeString(value);
+            comment = (comment != null) ? UnescapeString(comment) : null;
+         }
+
          return new IniKeyValue(key, value, comment);
+      }
+
+      private static string UnescapeString(string key)
+      {
+         return key.Replace(@"\r", "\r").Replace(@"\n", "\n");
       }
 
       public override string ToString()

--- a/src/Config.Net/Stores/Formats/Ini/IniSection.cs
+++ b/src/Config.Net/Stores/Formats/Ini/IniSection.cs
@@ -98,7 +98,7 @@ namespace Config.Net.Stores.Formats.Ini
                {
                   writer.Write(" ");
                   writer.Write(IniComment.CommentSeparator);
-                  writer.Write(ikv.Comment.Value);
+                  writer.Write(ikv.Comment.EscapedValue);
                }
                writer.WriteLine();
                continue;

--- a/src/Config.Net/Stores/Formats/Ini/IniSection.cs
+++ b/src/Config.Net/Stores/Formats/Ini/IniSection.cs
@@ -93,7 +93,7 @@ namespace Config.Net.Stores.Formats.Ini
             IniKeyValue? ikv = entity as IniKeyValue;
             if(ikv != null)
             {
-               writer.Write($"{ikv.Key}{IniKeyValue.KeyValueSeparator}{ikv.Value}");
+               writer.Write($"{ikv.EscapedKey}{IniKeyValue.KeyValueSeparator}{ikv.EscapedValue}");
                if(ikv.Comment != null)
                {
                   writer.Write(" ");

--- a/src/Config.Net/Stores/Formats/Ini/StructuredIniFile.cs
+++ b/src/Config.Net/Stores/Formats/Ini/StructuredIniFile.cs
@@ -60,7 +60,7 @@ namespace Config.Net.Stores.Formats.Ini
          }
       }
 
-      public static StructuredIniFile ReadFrom(Stream inputStream, bool parseInlineComments)
+      public static StructuredIniFile ReadFrom(Stream inputStream, bool parseInlineComments, bool unescapeNewLines = false)
       {
          if(inputStream == null) throw new ArgumentNullException(nameof(inputStream));
 
@@ -90,7 +90,7 @@ namespace Config.Net.Stores.Formats.Ini
                }
                else
                {
-                  IniKeyValue? ikv = IniKeyValue.FromLine(line, parseInlineComments);
+                  IniKeyValue? ikv = IniKeyValue.FromLine(line, parseInlineComments, unescapeNewLines);
                   if(ikv == null) continue;
 
                   section.Add(ikv);

--- a/src/Config.Net/Stores/IniFileConfigStore.cs
+++ b/src/Config.Net/Stores/IniFileConfigStore.cs
@@ -19,7 +19,7 @@ namespace Config.Net.Stores
       /// </summary>r
       /// <param name="name">File does not have to exist, however it will be created as soon as you
       /// try to write to it</param>
-      public IniFileConfigStore(string name, bool isFilePath, bool parseInlineComments)
+      public IniFileConfigStore(string name, bool isFilePath, bool parseInlineComments, bool unescapeNewLines = false)
       {
          if (name == null) throw new ArgumentNullException(nameof(name));
 
@@ -34,13 +34,13 @@ namespace Config.Net.Stores
                Directory.CreateDirectory(parentDirPath);
             }
 
-            _iniFile = ReadIniFile(_fullName, parseInlineComments);
+            _iniFile = ReadIniFile(_fullName, parseInlineComments, unescapeNewLines);
 
             CanWrite = true;
          }
          else
          {
-            _iniFile = ReadIniContent(name, parseInlineComments);
+            _iniFile = ReadIniContent(name, parseInlineComments, unescapeNewLines);
 
             CanWrite = false;
          }
@@ -78,14 +78,14 @@ namespace Config.Net.Stores
          WriteIniFile();
       }
 
-      private static StructuredIniFile ReadIniFile(string fullName, bool parseInlineComments)
+      private static StructuredIniFile ReadIniFile(string fullName, bool parseInlineComments, bool unescapeNewLines = false)
       {
          FileInfo iniFile = new FileInfo(fullName);
          if(iniFile.Exists)
          {
             using(FileStream stream = iniFile.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
-               return StructuredIniFile.ReadFrom(stream, parseInlineComments);
+               return StructuredIniFile.ReadFrom(stream, parseInlineComments, unescapeNewLines);
             }
          }
          else
@@ -94,11 +94,11 @@ namespace Config.Net.Stores
          }
       }
 
-      private static StructuredIniFile ReadIniContent(string content, bool parseInlineComments)
+      private static StructuredIniFile ReadIniContent(string content, bool parseInlineComments, bool unescapeNewLines = false)
       {
          using (Stream input = new MemoryStream(Encoding.UTF8.GetBytes(content)))
          {
-            return StructuredIniFile.ReadFrom(input, parseInlineComments);
+            return StructuredIniFile.ReadFrom(input, parseInlineComments, unescapeNewLines);
          }
       }
 


### PR DESCRIPTION
As discussed in #139 , this adds the following:

- \r and \n are always escaped when writing a file if found inside a key, value or comment.
- adds a bool option "unescapeNewLines" (default is false to avoid breaking backwards compatibility) that will convert "\r" and "\n" to the respective characters.
- Adds unit test cases for the above functionality.
- Added testing of comments to IniKeyValueTest and restructured it to use a common function.

If you don't like the way I restructured the test cases, I can remove that, but it simplified the whole thing a lot in my opinion.

This is my first pull request on github so if I'm doing something wrong, just tell me. ;)