### PR TITLE
Issue 65: Picking up the attributes when transforming to a collection

### DIFF
--- a/src/Config.Net.Tests/Stores/JsonFileCOnfigStoreTest.cs
+++ b/src/Config.Net.Tests/Stores/JsonFileCOnfigStoreTest.cs
@@ -50,9 +50,47 @@ namespace Config.Net.Tests.Stores
          Assert.Equal("111", _store.Read(key));
       }
 
+      [Fact]
+      public void AliasesOnCollections()
+      {
+         IMyConfigUsingAliases myConfig = new ConfigurationBuilder<IMyConfigUsingAliases>()
+            .UseConfigStore(_store)
+            .Build();
+
+         Assert.NotNull(myConfig.Credentials);
+         foreach (ICredsWithAlias c in myConfig.Credentials)
+         {
+            if (c.Name == "user1")
+            {
+               Assert.Equal("pass1", c.Pass);
+            }
+            else if (c.Name == "user2")
+            {
+               Assert.Equal("pass2", c.Pass);
+            }
+            else
+            {
+               Assert.Equal("user1", c.Name);
+            }
+         }
+      }
+
       public void Dispose()
       {
          _store.Dispose();
       }
+   }
+   public interface ICredsWithAlias
+   {
+      [Option(Alias = "Username")]
+      string Name { get; set; }
+      [Option(Alias = "Password")]
+      string Pass { get; set; }
+   }
+
+   public interface IMyConfigUsingAliases
+   {
+      [Option(Alias = "Creds")]
+      IEnumerable<ICredsWithAlias> Credentials { get; }
    }
 }

--- a/src/Config.Net/Core/Box/BoxFactory.cs
+++ b/src/Config.Net/Core/Box/BoxFactory.cs
@@ -56,6 +56,7 @@ namespace Config.Net.Core.Box
             if(isCollection)
             {
                rbox = new CollectionResultBox(pi.Name, rbox);
+               AddAttributes(rbox, pi, valueHandler);
             }
 
             result[pi.Name] = rbox;


### PR DESCRIPTION
For issue #65 it looks like the main failing point was that attributes applied to the underlying Box did not similarly get applied to the CollectionResultBox. 

Since the original code was written for the CollectionResultBox to be a wrapper around another result box, it seemed like it was best to keep that as similar as possible, as opposed to updating CollectionResultBox to also be a ProxyResultBox and initialize it directly.

